### PR TITLE
Bump rack and sinatra in /rb175/lesson_8/file_based_cms

### DIFF
--- a/rb175/lesson_8/file_based_cms/Gemfile
+++ b/rb175/lesson_8/file_based_cms/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem "sinatra", "~>1.4.7"
+gem "sinatra", "~>2.0.8"
 gem "sinatra-contrib"
 gem "erubis"
 gem "rack", ">= 1.6.12"

--- a/rb175/lesson_8/file_based_cms/Gemfile.lock
+++ b/rb175/lesson_8/file_based_cms/Gemfile.lock
@@ -1,28 +1,32 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    backports (3.17.0)
+    backports (3.18.1)
     bcrypt (3.1.13)
     erubis (2.7.0)
     minitest (5.14.0)
     multi_json (1.14.1)
-    rack (1.6.13)
-    rack-protection (1.5.5)
+    mustermann (1.1.1)
+      ruby2_keywords (~> 0.0.1)
+    rack (2.2.3)
+    rack-protection (2.0.8.1)
       rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     redcarpet (3.5.0)
-    sinatra (1.4.8)
-      rack (~> 1.5)
-      rack-protection (~> 1.4)
-      tilt (>= 1.3, < 3)
-    sinatra-contrib (1.4.7)
-      backports (>= 2.0)
+    ruby2_keywords (0.0.2)
+    sinatra (2.0.8.1)
+      mustermann (~> 1.0)
+      rack (~> 2.0)
+      rack-protection (= 2.0.8.1)
+      tilt (~> 2.0)
+    sinatra-contrib (2.0.8.1)
+      backports (>= 2.8.2)
       multi_json
-      rack-protection
-      rack-test
-      sinatra (~> 1.4.0)
-      tilt (>= 1.3, < 3)
+      mustermann (~> 1.0)
+      rack-protection (= 2.0.8.1)
+      sinatra (= 2.0.8.1)
+      tilt (~> 2.0)
     tilt (2.0.10)
 
 PLATFORMS
@@ -36,7 +40,7 @@ DEPENDENCIES
   rack-protection (>= 1.5.5)
   rack-test
   redcarpet
-  sinatra (~> 1.4.7)
+  sinatra (~> 2.0.8)
   sinatra-contrib
 
 RUBY VERSION


### PR DESCRIPTION
Bumps [rack](https://github.com/rack/rack) and [sinatra](https://github.com/sinatra/sinatra). These dependencies needed to be updated together.

Updates `rack` from 1.6.13 to 2.2.3
- [Release notes](https://github.com/rack/rack/releases)
- [Changelog](https://github.com/rack/rack/blob/master/CHANGELOG.md)
- [Commits](https://github.com/rack/rack/compare/1.6.13...2.2.3)

Updates `sinatra` from 1.4.8 to 2.0.8.1
- [Release notes](https://github.com/sinatra/sinatra/releases)
- [Changelog](https://github.com/sinatra/sinatra/blob/master/CHANGELOG.md)
- [Commits](https://github.com/sinatra/sinatra/compare/v1.4.8...v2.0.8.1)

Signed-off-by: dependabot[bot] <support@github.com>